### PR TITLE
Feat: add custom descriptions

### DIFF
--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -51,6 +51,7 @@ class TypedValue {
  * @param {radspec/Bindings} bindings An object of bindings and their values
  * @param {?Object} options An options object
  * @param {?Object} options.availablehelpers Available helpers
+ * @param {?Object} options.availableFunctions Available function signatures
  * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
  * @param {?string} options.to The destination address for this expression's transaction
  * @property {radspec/parser/AST} ast
@@ -60,7 +61,7 @@ export class Evaluator {
   constructor (
     ast,
     bindings,
-    { availableHelpers = {}, provider, from, to, value = '0', data } = {}
+    { availableHelpers = {}, availableFunctions = {}, provider, from, to, value = '0', data } = {}
   ) {
     this.ast = ast
     this.bindings = bindings
@@ -71,6 +72,7 @@ export class Evaluator {
     this.value = new TypedValue('uint', BigNumber.from(value))
     this.data = data && new TypedValue('bytes', data)
     this.helpers = new HelperManager(availableHelpers)
+    this.functions = availableFunctions
   }
 
   /**
@@ -297,7 +299,8 @@ export class Evaluator {
       const inputs = await this.evaluateNodes(node.inputs)
       const result = await this.helpers.execute(helperName, inputs, {
         provider: this.provider,
-        evaluator: this
+        evaluator: this,
+        functions: this.functions
       })
 
       return new TypedValue(result.type, result.value)
@@ -367,6 +370,7 @@ export class Evaluator {
  * @param {radspec/Bindings} bindings An object of bindings and their values
  * @param {?Object} options An options object
  * @param {?Object} options.availablehelpers Available helpers
+ * @param {?Object} options.availableFunctions Available function signatures
  * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
  * @param {?string} options.to The destination address for this expression's transaction
  * @return {string}

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -2,7 +2,7 @@
  * @module radspec/evaluator
  */
 
-import { ethers, BigNumber } from 'ethers'
+import { BigNumber, providers as ethersProvider, utils as ethersUtils } from 'ethers'
 
 import types from '../types'
 import HelperManager from '../helpers/HelperManager'
@@ -26,10 +26,10 @@ class TypedValue {
     }
 
     if (this.type === 'address') {
-      if (!ethers.utils.isAddress(this.value)) {
+      if (!ethersUtils.isAddress(this.value)) {
         throw new Error(`Invalid address "${this.value}"`)
       }
-      this.value = ethers.utils.getAddress(this.value)
+      this.value = ethersUtils.getAddress(this.value)
     }
   }
 
@@ -52,7 +52,7 @@ class TypedValue {
  * @param {?Object} options An options object
  * @param {?Object} options.availablehelpers Available helpers
  * @param {?Object} options.availableFunctions Available function signatures
- * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
+ * @param {?ethersProvider.Provider} options.provider EIP 1193 provider
  * @param {?string} options.to The destination address for this expression's transaction
  * @property {radspec/parser/AST} ast
  * @property {radspec/Bindings} bindings
@@ -243,7 +243,7 @@ export class Evaluator {
 
       if (target.type !== 'bytes20' && target.type !== 'address') {
         this.panic('Target of call expression was not an address')
-      } else if (!ethers.utils.isAddress(target.value)) {
+      } else if (!ethersUtils.isAddress(target.value)) {
         this.panic(`Invalid address "${this.value}"`)
       }
 
@@ -272,7 +272,7 @@ export class Evaluator {
           stateMutability: 'view'
         }
       ]
-      const ethersInterface = new ethers.utils.Interface(abi)
+      const ethersInterface = new ethersUtils.Interface(abi)
 
       const txData = ethersInterface.encodeFunctionData(
         node.callee,
@@ -371,7 +371,7 @@ export class Evaluator {
  * @param {?Object} options An options object
  * @param {?Object} options.availablehelpers Available helpers
  * @param {?Object} options.availableFunctions Available function signatures
- * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
+ * @param {?ethersProvider.Provider} options.provider EIP 1193 provider
  * @param {?string} options.to The destination address for this expression's transaction
  * @return {string}
  */

--- a/src/helpers/HelperManager.js
+++ b/src/helpers/HelperManager.js
@@ -29,7 +29,7 @@ export default class HelperManager {
    * @param  {string} helper Helper name
    * @param  {Array<radspec/evaluator/TypedValue>} inputs
    * @param  {Object} config Configuration for running helper
-   * @param  {ethers.providers.Provider} config.provider Current provider
+   * @param  {ethersProvider.Provider} config.provider Current provider
    * @param  {radspec/evaluator/Evaluator} config.evaluator Current evaluator
    * @param  {Object} config.functions Current function signatures
    * @return {Promise<radspec/evaluator/TypedValue>}

--- a/src/helpers/HelperManager.js
+++ b/src/helpers/HelperManager.js
@@ -29,13 +29,14 @@ export default class HelperManager {
    * @param  {string} helper Helper name
    * @param  {Array<radspec/evaluator/TypedValue>} inputs
    * @param  {Object} config Configuration for running helper
-   * @param {ethers.providers.Provider} config.provider Current provider
+   * @param  {ethers.providers.Provider} config.provider Current provider
    * @param  {radspec/evaluator/Evaluator} config.evaluator Current evaluator
+   * @param  {Object} config.functions Current function signatures
    * @return {Promise<radspec/evaluator/TypedValue>}
    */
-  execute (helper, inputs, { provider, evaluator }) {
+  execute (helper, inputs, { provider, evaluator, functions }) {
     inputs = inputs.map((input) => input.value) // pass values directly
-    return this.availableHelpers[helper](provider, evaluator)(...inputs)
+    return this.availableHelpers[helper](provider, evaluator, functions)(...inputs)
   }
 
   /**

--- a/src/helpers/fromHex.js
+++ b/src/helpers/fromHex.js
@@ -1,4 +1,4 @@
-import { ethers, BigNumber } from 'ethers'
+import { BigNumber, utils as ethersUtils } from 'ethers'
 
 export default () =>
   /**
@@ -13,5 +13,5 @@ export default () =>
     value:
       to === 'number'
         ? BigNumber.from(hex).toNumber()
-        : ethers.utils.toUtf8String(hex)
+        : ethersUtils.toUtf8String(hex)
   })

--- a/src/helpers/lib/methodRegistry.js
+++ b/src/helpers/lib/methodRegistry.js
@@ -1,5 +1,5 @@
 // From: https://github.com/danfinlay/eth-method-registry
-import { ethers } from 'ethers'
+import { Contract, providers as ethersProviders } from 'ethers'
 
 const REGISTRY_LOOKUP_ABI = [
   'function entries(bytes4) public view returns (string)'
@@ -22,7 +22,7 @@ export default class MethodRegistry {
       throw new Error('No method registry found for the network.')
     }
 
-    this.registry = new ethers.Contract(
+    this.registry = new Contract(
       this.registryAddres,
       REGISTRY_LOOKUP_ABI,
       this.provider

--- a/src/helpers/radspec.js
+++ b/src/helpers/radspec.js
@@ -1,8 +1,7 @@
-import { ethers } from 'ethers'
+import { utils as ethersUtils } from 'ethers'
 
 import MethodRegistry from './lib/methodRegistry'
 import { evaluateRaw } from '../lib/'
-import { knownFunctions } from '../data/'
 import { DEFAULT_API_4BYTES } from '../defaults'
 
 const makeUnknownFunctionNode = (methodId) => ({
@@ -11,7 +10,7 @@ const makeUnknownFunctionNode = (methodId) => ({
 })
 
 const parse = (signature) => {
-  const fragment = ethers.utils.FunctionFragment.from(signature)
+  const fragment = ethersUtils.FunctionFragment.from(signature)
 
   return {
     name:
@@ -27,24 +26,24 @@ const parse = (signature) => {
 }
 
 // Hash signature with Ethereum Identity and silce bytes
-const getSigHah = (sig) => ethers.utils.hexDataSlice(ethers.utils.id(sig), 0, 4)
+const getSigHah = (sig) => ethersUtils.hexDataSlice(ethersUtils.id(sig), 0, 4)
 
 // Convert from the knownFunctions data format into the needed format
 // Input: { "signature(type1,type2)": "Its radspec string", ... }
 // Output: { "0xabcdef12": { "fragment": FunctionFragment, "source": "Its radspec string" }, ...}
 const processFunctions = (functions) =>
   Object.keys(functions).reduce((acc, key) => {
-    const fragment = ethers.utils.FunctionFragment.from(key)
+    const fragment = ethersUtils.FunctionFragment.from(key)
     return {
       [getSigHah(fragment.format())]: { source: functions[key], fragment },
       ...acc
     }
   }, {})
 
-export default (provider, evaluator) =>
+export default (provider, evaluator, functions) =>
   /**
    * Interpret calldata using radspec recursively. If the function signature is not in the package's known
-   * functions, it fallbacks to looking for the function name using github.com/parity-contracts/signature-registry
+   * functions, it fallbacks to looking for the function name using github.com/parity-contracts/signature-registry and finally using 4bytes API
    *
    * @param {address} addr The target address of the call
    * @param {bytes} data The calldata of the call
@@ -52,7 +51,7 @@ export default (provider, evaluator) =>
    * @return {Promise<radspec/evaluator/TypedValue>}
    */
   async (addr, data, registryAddress) => {
-    const functions = processFunctions(knownFunctions)
+    const processedFunctions = processFunctions(functions)
 
     if (data.length < 10) {
       return makeUnknownFunctionNode(data)
@@ -60,7 +59,7 @@ export default (provider, evaluator) =>
 
     // Get method ID
     const methodId = data.substr(0, 10)
-    const fn = functions[methodId]
+    const fn = processedFunctions[methodId]
 
     // If function is not a known function
     if (!fn) {
@@ -81,25 +80,29 @@ export default (provider, evaluator) =>
           value: name // TODO: should we decode and print the arguments as well?
         }
       } catch {
+        try {
         // Try fetching 4bytes API
-        const { results } = await ethers.utils.fetchJson(
-          `${DEFAULT_API_4BYTES}?hex_signature=${methodId}`
-        )
-        if (Array.isArray(results) && results.length > 0) {
-          const { name } = parse(results[0].text_signature)
-          return {
-            type: 'string',
-            value: name
+          const { results } = await ethersUtils.fetchJson({
+            url: `${DEFAULT_API_4BYTES}?hex_signature=${methodId}`,
+            timeout: 3000
+          })
+          if (Array.isArray(results) && results.length > 0) {
+            const { name } = parse(results[0].text_signature)
+            return {
+              type: 'string',
+              value: name
+            }
           }
+        } catch {
+          // Fallback to unknown function
+          return makeUnknownFunctionNode(methodId)
         }
-        // Fallback to unknown function
-        return makeUnknownFunctionNode(methodId)
       }
     }
     // If the function was found in local radspec registry. Decode and evaluate.
     const { source, fragment } = fn
 
-    const ethersInterface = new ethers.utils.Interface([fragment])
+    const ethersInterface = new ethersUtils.Interface([fragment])
 
     // Decode parameters
     const args = ethersInterface.decodeFunctionData(fragment.name, data)
@@ -120,6 +123,7 @@ export default (provider, evaluator) =>
       value: await evaluateRaw(source, parameters, {
         provider,
         availableHelpers: evaluator.helpers.getHelpers(),
+        availableFunctions: functions,
         to: addr
       })
     }

--- a/src/helpers/tokenAmount.js
+++ b/src/helpers/tokenAmount.js
@@ -1,4 +1,4 @@
-import { ethers, BigNumber } from 'ethers'
+import { BigNumber, Contract, utils as ethersUtils } from 'ethers'
 
 import {
   ERC20_SYMBOL_BYTES32_ABI,
@@ -30,7 +30,7 @@ export default (provider) =>
         symbol = 'ETH'
       }
     } else {
-      let token = new ethers.Contract(
+      let token = new Contract(
         tokenAddress,
         ERC20_SYMBOL_DECIMALS_ABI,
         provider
@@ -42,13 +42,13 @@ export default (provider) =>
           symbol = (await token.symbol()) || ''
         } catch (err) {
           // Some tokens (e.g. DS-Token) use bytes32 for their symbol()
-          token = new ethers.Contract(
+          token = new Contract(
             tokenAddress,
             ERC20_SYMBOL_BYTES32_ABI,
             provider
           )
           symbol = (await token.symbol()) || ''
-          symbol = symbol && ethers.utils.toUtf8String(symbol)
+          symbol = symbol && ethersUtils.toUtf8String(symbol)
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { knownFunctions } from './data'
+
 /**
  * @typedef {Object} Binding
  * @property {string} type The type of the binding (a valid Radspec type)
@@ -40,9 +42,10 @@ import { evaluateRaw } from './lib'
  * @param {?Object} options An options object
  * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
  * @param {?Object} options.userHelpers User defined helpers
+ * @param {?Object} options.userFunctions User defined function signatures
  * @return {Promise<string>} The result of the evaluation
  */
-function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
+function evaluate (source, call, { userHelpers = {}, userFunctions = {}, ...options } = {}) {
   // Create ethers interface object
   const ethersInterface = new ethers.utils.Interface(call.abi)
 
@@ -64,6 +67,8 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
 
   const availableHelpers = { ...defaultHelpers, ...userHelpers }
 
+  const availableFunctions = { ...knownFunctions, ...userFunctions }
+
   // Get additional options
   const { from, to, value, data } = call.transaction
 
@@ -71,6 +76,7 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
   return evaluateRaw(source, parameters, {
     ...options,
     availableHelpers,
+    availableFunctions,
     from,
     to,
     value,

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import { knownFunctions } from './data'
 /**
  * @module radspec
  */
-import { ethers } from 'ethers'
+import { utils as ethersUtils } from 'ethers'
 import { defaultHelpers } from './helpers'
 import { evaluateRaw } from './lib'
 
@@ -40,14 +40,14 @@ import { evaluateRaw } from './lib'
  * @param {string} call.transaction.to The destination address for this transaction
  * @param {string} call.transaction.data The transaction data
  * @param {?Object} options An options object
- * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
+ * @param {?ethersProvider.Provider} options.provider EIP 1193 provider
  * @param {?Object} options.userHelpers User defined helpers
  * @param {?Object} options.userFunctions User defined function signatures
  * @return {Promise<string>} The result of the evaluation
  */
 function evaluate (source, call, { userHelpers = {}, userFunctions = {}, ...options } = {}) {
   // Create ethers interface object
-  const ethersInterface = new ethers.utils.Interface(call.abi)
+  const ethersInterface = new ethersUtils.Interface(call.abi)
 
   // Parse as an ethers TransactionDescription
   const { args, functionFragment } = ethersInterface.parseTransaction(

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -1,10 +1,10 @@
 import test from 'ava'
-import { BigNumber, ethers } from 'ethers'
+import { BigNumber, utils as ethersUtils } from 'ethers'
+import { knownFunctions } from '../../src/data'
 import { evaluateRaw } from '../../src/lib'
 import { defaultHelpers } from '../../src/helpers'
 import { tenPow } from '../../src/helpers/lib/formatBN'
 import { ETH } from '../../src/helpers/lib/token'
-import knownFunctions from '../../src/data/knownFunctions'
 
 const int = (value) => ({
   type: 'int256',
@@ -821,7 +821,7 @@ const cases = [
   [{
     source: 'Performs a call to `@radspec(contract, msg.data)`',
     bindings: { contract: address('0x960b236A07cf122663c4303350609A66A7B288C0') },
-    options: { data: ethers.utils.keccak256(ethers.utils.toUtf8Bytes(Object.keys(knownFunctions)[3])).slice(0, 10) }
+    options: { data: ethersUtils.keccak256(ethersUtils.toUtf8Bytes(Object.keys(knownFunctions)[3])).slice(0, 10) }
   }, `Performs a call to ${Object.values(knownFunctions)[3]}`],
 
   ...comparisonCases,
@@ -831,13 +831,14 @@ const cases = [
 
 cases.forEach(([input, expected], index) => {
   test(`${index} - ${input.source}`, async (t) => {
-    const { userHelpers } = input.options || {}
+    const { userHelpers, userFunctions } = input.options || {}
     const actual = await evaluateRaw(
       input.source,
       input.bindings,
       {
         ...input.options,
-        availableHelpers: { ...defaultHelpers, ...userHelpers }
+        availableHelpers: { ...defaultHelpers, ...userHelpers },
+        availableFunctions: { ...knownFunctions, ...userFunctions }
       }
     )
     t.is(

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -259,7 +259,7 @@ const dataDecodeCases = [
     source: 'Melonprotocol: `@radspec(addr, data)`',
     bindings: {
       addr: address(),
-      data: bytes('0xbda53107000000000000000000000000ec67005c4e498ec7f55e092bd1d35cbc47c91892') // setPriceSource(address), on melonprotocol's knownFunctions
+      data: bytes('0xbda53100700000000000000000000000ec67005c4e498ec7f55e092bd1d35cbc47c91892') // setPriceSource(address), on melonprotocol's knownFunctions
     }
   }, 'Melonprotocol: Set price source to 0xec67005c4E498Ec7f55E092bd1d35cbC47C91892'],
   [{

--- a/test/index.js
+++ b/test/index.js
@@ -1,40 +1,82 @@
-import test from 'ava'
-import { evaluate } from '../src'
+import test from "ava";
+import { ethers } from "ethers";
+import { evaluate } from "../src";
 
-test('radspec#evaluate json abi', async (t) => {
-  const expression = 'Will multiply `a` by 7 and return `a * 7`.'
+const XDAI_ENDPOINT = "https://rpc.xdaichain.com";
+
+test("radspec#evaluate json abi", async (t) => {
+  const expression = "Will multiply `a` by 7 and return `a * 7`.";
   const call = {
-    abi: [{
-      name: 'multiply',
-      constant: false,
-      type: 'function',
-      inputs: [{
-        name: 'a',
-        type: 'uint256'
-      }],
-      outputs: [{
-        name: 'd',
-        type: 'uint256'
-      }]
-    }],
+    abi: [
+      {
+        name: "multiply",
+        constant: false,
+        type: "function",
+        inputs: [
+          {
+            name: "a",
+            type: "uint256",
+          },
+        ],
+        outputs: [
+          {
+            name: "d",
+            type: "uint256",
+          },
+        ],
+      },
+    ],
     transaction: {
-      to: '0x8521742d3f456BD237E312d6E30724960f72517A',
-      data: '0xc6888fa1000000000000000000000000000000000000000000000000000000000000007a'
-    }
-  }
+      to: "0x8521742d3f456BD237E312d6E30724960f72517A",
+      data: "0xc6888fa1000000000000000000000000000000000000000000000000000000000000007a",
+    },
+  };
 
-  t.is(await evaluate(expression, call), 'Will multiply 122 by 7 and return 854.')
-})
+  t.is(
+    await evaluate(expression, call),
+    "Will multiply 122 by 7 and return 854."
+  );
+});
 
-test('radspec#evaluate Human-Readable abi', async (t) => {
-  const expression = 'Will multiply `a` by 7 and return `a * 7`.'
+test("radspec#evaluate Human-Readable abi", async (t) => {
+  const expression = "Will multiply `a` by 7 and return `a * 7`.";
   const call = {
-    abi: ['function multiply(uint256 a) public view returns(uint256)'],
+    abi: ["function multiply(uint256 a) public view returns(uint256)"],
     transaction: {
-      to: '0x8521742d3f456BD237E312d6E30724960f72517A',
-      data: '0xc6888fa1000000000000000000000000000000000000000000000000000000000000007a'
-    }
-  }
+      to: "0x8521742d3f456BD237E312d6E30724960f72517A",
+      data: "0xc6888fa1000000000000000000000000000000000000000000000000000000000000007a",
+    },
+  };
 
-  t.is(await evaluate(expression, call), 'Will multiply 122 by 7 and return 854.')
-})
+  t.is(
+    await evaluate(expression, call),
+    "Will multiply 122 by 7 and return 854."
+  );
+});
+
+// TODO: include userFunctions test
+// test("radspec#evaluate Helper userFunctions", async (t) => {
+//   const expression = null;
+//   const call = {
+//     abi: [
+//       "function stakeToProposal(uint256 _proposalId, uint256 _amount) external",
+//     ],
+//     transaction: {
+//       to: "0x0b21081c6f8b1990f53fc76279cc41ba22d7afe2",
+//       data: "0xfc3700510000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000002a48286b8d60482b9",
+//     },
+//   };
+
+//   const options = {
+//     provider: new ethers.providers.StaticJsonRpcProvider(XDAI_ENDPOINT),
+//     userFunctions: {
+//       "stakeToProposal(uint256,uint256)":
+//         "Stake `@tokenAmount((self.stakeToken(): address), _amount)` on proposal #`_proposalId`",
+//     },
+//   };
+
+//   t.is(
+//     await evaluate(expression, call, options),
+//     "Stake 48.747673445034394297 on proposal #66"
+//   );
+// });


### PR DESCRIPTION
This PR includes a new feature that allows consumers to define custom radspec descriptions for a list of known functions.

In the context of the Aragon Client, the consumer was not able to customize this list and that's why we have this data folder for each project: https://github.com/aragon/radspec/tree/master/src/data

With the help of Aragon Connect the above limitation is no longer relevant. Having a way to customize radspec descriptions is going to give much more flexibility to the Connect users.